### PR TITLE
TCP connection handling improvements

### DIFF
--- a/src/modules/connection-tcp.ts
+++ b/src/modules/connection-tcp.ts
@@ -28,6 +28,7 @@ const CUSTOM_MESSAGES_TYPES = [
 ]
 
 const CUSTOM_LISTENER_TYPES = [
+    'connecting',
     'data',
     'disconnect',
     'xml',
@@ -233,6 +234,11 @@ export class ConnectionTCP {
      */
     protected attemptEstablishConnection = (): void => {
         this._debug && console.log(`[node-vmix] Attempting to establish TCP socket connection to vMix instance ${this._host}:${this._port}`)
+
+        // Emit connecting event
+        this._listeners.connecting.forEach((cb: Function) => {
+            cb()
+        })
 
         // Attempt establishing connection
         this._socket.connect(this._port, this._host)

--- a/src/modules/connection-tcp.ts
+++ b/src/modules/connection-tcp.ts
@@ -630,6 +630,10 @@ export class ConnectionTCP {
     shutdown(): void {
         // stop trying to reconnect after being instructed to shutdown.
         this._autoReconnect = false
+        if (this._reconnectionInterval) {
+            clearInterval(this._reconnectionInterval)
+            this._reconnectionInterval = null
+        }
 
         // kill client after server's response
         this.send('quit')


### PR DESCRIPTION
A couple of improvements for TCP connection handling.

I can of course also split these into three separate PRs if you'd like.

1. Clear the reconnect interval when `shutdown()` is called. This fixes a bug where calling `shutdown()` on a connection that hadn't been established yet would not stop reconnects.

2. Add a `connecting` event that fires when trying to establish a connection. I needed this to give feedback to the user about the current connection state.

3. Add a socket connect timeout (currently set to 5 seconds). Previously, if the target host was down, it would wait for a very long time until reconnecting and the reconnect interval didn't really properly work either. Because the timeout handler needs to call `socket.destroy()`, this required moving most of the socket initialization code into `attemptEstablishConnection()`. Unfortunately GitHub's diff is a little wonky for this commit due to the amount of code that was moved around.

I've run a bunch of tests with reachable hosts, unreachable hosts, reconnects, etc., and I'm pretty confident that everything still works as it should.